### PR TITLE
Reduce package json @types/vscode version

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,7 +223,7 @@
         "@types/mocha": "^5.2.6",
         "@types/node": "^10.17.12",
         "@types/node-fetch": "^2.5.4",
-        "@types/vscode": "1.42.0",
+        "@types/vscode": "^1.33.0",
         "@typescript-eslint/eslint-plugin": "^2.13.0",
         "@typescript-eslint/parser": "^2.13.0",
         "@zeplin/eslint-config": "^2.2.0",


### PR DESCRIPTION
This change does not actually reduce @vscode/types version, it just tricks
"vsce package" command while packaging the extension because
that command requires engines.vscode version to be greater than
@vscode/types version. We can not do that because we support older
vscode versions and disable some features at runtime. So this change
is used as a workaround.