### PR TITLE
Remove barrel selection from jump to

### DIFF
--- a/src/coco/zeplinComponent/util/zeplinComponentUtil.ts
+++ b/src/coco/zeplinComponent/util/zeplinComponentUtil.ts
@@ -1,11 +1,12 @@
 import ZeplinComponentSection from "../../../common/domain/zeplinComponent/model/ZeplinComponentSection";
 import ZeplinComponent from "../../../common/domain/zeplinComponent/model/ZeplinComponent";
 import BarrelDetailsResponse from "../../../common/domain/barrel/model/BarrelDetailsResponse";
+import BarrelType from "../../../common/domain/barrel/BarrelType";
 
-function getComponentsFromSections(barrel: BarrelDetailsResponse): ZeplinComponent[] {
+function getComponentsFromSections(barrel: BarrelDetailsResponse, barrelType: BarrelType): ZeplinComponent[] {
     return getComponentsFromSectionsAdditive(
-        barrel._id,
-        barrel.name,
+        barrel,
+        barrelType,
         barrel.componentSections.map(section => ({
             section,
             nameBreadcrumbs: [],
@@ -17,13 +18,14 @@ function getComponentsFromSections(barrel: BarrelDetailsResponse): ZeplinCompone
 }
 
 function getComponentsFromSectionsAdditive( // eslint-disable-line max-params
-    barrelId: string,
-    barrelName: string,
+    barrel: BarrelDetailsResponse,
+    barrelType: BarrelType,
     sectionWithBreadcrumbsArray: SectionWithBreadcrumbs[],
     defaultSection: boolean,
     accumulator: ZeplinComponent[]
 ): ZeplinComponent[] {
     if (sectionWithBreadcrumbsArray && sectionWithBreadcrumbsArray.length) {
+        const { _id: barrelId, name: barrelName } = barrel;
         const { section, nameBreadcrumbs, idBreadcrumbs } = sectionWithBreadcrumbsArray.shift()!;
 
         accumulator.push(
@@ -34,6 +36,7 @@ function getComponentsFromSectionsAdditive( // eslint-disable-line max-params
                     name: component.name,
                     latestVersion: component.latestVersion,
                     barrelId,
+                    barrelType,
                     barrelName,
                     sectionIds: defaultSection ? idBreadcrumbs : idBreadcrumbs.concat(section._id),
                     sectionNames: defaultSection ? nameBreadcrumbs : nameBreadcrumbs.concat(section.name)
@@ -54,7 +57,7 @@ function getComponentsFromSectionsAdditive( // eslint-disable-line max-params
             );
         }
 
-        return getComponentsFromSectionsAdditive(barrelId, barrelName, sectionWithBreadcrumbsArray, false, accumulator);
+        return getComponentsFromSectionsAdditive(barrel, barrelType, sectionWithBreadcrumbsArray, false, accumulator);
     }
 
     return accumulator;

--- a/src/common/domain/barrel/data/BarrelDetailsStore.ts
+++ b/src/common/domain/barrel/data/BarrelDetailsStore.ts
@@ -31,7 +31,7 @@ export default abstract class BarrelDetailsStore<T extends BarrelDetailsResponse
             thumbnail: response.thumbnail,
             parentId: this.getParent(response),
             description: response.description,
-            components: getComponentsFromSections(response),
+            components: getComponentsFromSections(response, this.type),
             componentSections: response.componentSections,
             screenSections: response.sections,
             jiras: getProjectJiras(response),

--- a/src/common/domain/zeplinComponent/model/ZeplinComponent.ts
+++ b/src/common/domain/zeplinComponent/model/ZeplinComponent.ts
@@ -1,7 +1,9 @@
 import ResponseZeplinComponent from "./ResponseZeplinComponent";
+import BarrelType from "../../barrel/BarrelType";
 
 export default interface ZeplinComponent extends ResponseZeplinComponent {
     barrelId: string;
+    barrelType: BarrelType;
     barrelName: string;
     sectionIds: string[];
     sectionNames: string[];

--- a/src/sidebar/screen/model/Screen.ts
+++ b/src/sidebar/screen/model/Screen.ts
@@ -2,6 +2,8 @@ import JiraAttachable from "../../../common/domain/jira/model/JiraAttachable";
 import ResponseScreen from "./ResponseScreen";
 
 export default interface Screen extends ResponseScreen, JiraAttachable {
+    barrelId: string;
+    barrelName: string;
     sectionId?: string;
     sectionName?: string;
 }

--- a/src/sidebar/screen/util/screenUi.ts
+++ b/src/sidebar/screen/util/screenUi.ts
@@ -1,11 +1,10 @@
 import Screen from "../model/Screen";
-import Barrel from "../../../common/domain/barrel/Barrel";
 import localization from "../../../localization";
 
 const DETAIL_ITEM_SEPARATOR = " ▸ ";
 
-function getScreenDetailRepresentation(screen: Screen, barrel: Barrel): string {
-    return [barrel.name, localization.sidebar.screen.screens, screen.sectionName]
+function getScreenDetailRepresentation(screen: Screen): string {
+    return [screen.barrelName, localization.sidebar.screen.screens, screen.sectionName]
         .filter(representation => representation)
         .join(DETAIL_ITEM_SEPARATOR);
 }


### PR DESCRIPTION
All screens and components of all barrels on the sidebar are shown at once
on the picker.