### PR TITLE
Fix data not being updated when barrel is re-added

### DIFF
--- a/src/common/domain/store/BasicStore.ts
+++ b/src/common/domain/store/BasicStore.ts
@@ -40,6 +40,10 @@ implements Store<TData, TError>, CacheHolder, vscode.Disposable {
         }
     };
 
+    public getCache() {
+        return this.cache;
+    }
+
     private async getResultFromFetchPromise(): Promise<Result<TData, TError>> {
         const result = await this.fetchPromise!;
         if (result instanceof BaseError) {

--- a/src/common/domain/zeplinComponent/data/BarrelDetailsStoreProvider.ts
+++ b/src/common/domain/zeplinComponent/data/BarrelDetailsStoreProvider.ts
@@ -27,6 +27,16 @@ class BarrelDetailsStoreProvider implements CacheHolder {
         Object.keys(this.cache).forEach(key => this.cache[key].dispose());
         this.cache = {};
     }
+
+    public clearCacheFor(id: string) {
+        let currentId: string | undefined = id;
+        while (currentId && this.cache[currentId]) {
+            const nextId: string | undefined = this.cache[currentId].getCache()?.data?.parentId;
+            this.cache[currentId].dispose();
+            delete this.cache[currentId];
+            currentId = nextId;
+        }
+    }
 }
 
 export default new BarrelDetailsStoreProvider();

--- a/src/sidebar/barrel/util/barrelUtil.ts
+++ b/src/sidebar/barrel/util/barrelUtil.ts
@@ -3,6 +3,8 @@ import ContextProvider from "../../../common/vscode/extension/ContextProvider";
 import BarrelTreeDataProvider from "../tree/BarrelTreeDataProvider";
 import ActivityTreeDataProvider from "../../activity/tree/ActivityTreeDataProvider";
 import { removeBarrelItemsFromPinnedItems } from "../../pin/util/pinUtil";
+import ScreensStoreProvider from "../../screen/data/ScreensStoreProvider";
+import BarrelDetailsStoreProvider from "../../../common/domain/zeplinComponent/data/BarrelDetailsStoreProvider";
 
 const KEY_SAVED_BARRELS = "sidebar.savedBarrels";
 
@@ -35,6 +37,8 @@ function saveBarrel(barrel: Barrel) {
 function removeBarrel(barrel: Barrel) {
     const barrels = getSavedBarrels().filter(savedBarrel => savedBarrel.id !== barrel.id);
     saveBarrels(barrels);
+    ScreensStoreProvider.clearCacheFor(barrel.id);
+    BarrelDetailsStoreProvider.clearCacheFor(barrel.id);
     removeBarrelItemsFromPinnedItems(barrel);
 }
 

--- a/src/sidebar/screen/data/ScreensStoreProvider.ts
+++ b/src/sidebar/screen/data/ScreensStoreProvider.ts
@@ -18,6 +18,11 @@ class ScreensStoreProvider implements CacheHolder {
         Object.keys(this.cache).forEach(key => this.cache[key].dispose());
         this.cache = {};
     }
+
+    public clearCacheFor(id: string) {
+        this.cache[id]?.dispose();
+        delete this.cache[id];
+    }
 }
 
 export default new ScreensStoreProvider();


### PR DESCRIPTION
This fixes a bug when a project data is changed after it is removed
from the sidebar and added back, the data was shown as the old version