### PR TITLE
Open link of components instead of barrels

### DIFF
--- a/src/common/domain/openInZeplin/util/zeplinUris.ts
+++ b/src/common/domain/openInZeplin/util/zeplinUris.ts
@@ -58,6 +58,38 @@ function getBarrelWebUrl(barrelId: string, barrelType: BarrelType): string {
     return barrelType === BarrelType.Project ? getProjectWebUrl(barrelId) : getStyleguideWebUrl(barrelId);
 }
 
+/**
+ * Returns a barrel's components' app uri
+ * @param barrelId A barrel id.
+ * @param barrelType A barrel type.
+ * @param applicationType Type of app to create uri of.
+ */
+function getComponentsUri(barrelId: string, barrelType: BarrelType, applicationType: ApplicationType): string {
+    return applicationType === ApplicationType.Web
+        ? getComponentsWebUrl(barrelId, barrelType)
+        : getComponentsAppUri(barrelId, barrelType);
+}
+
+/**
+ * Returns a barrel's components' Web app url
+ * @param barrelId A barrel id.
+ * @param barrelType A barrel type.
+ */
+function getComponentsWebUrl(barrelId: string, barrelType: BarrelType): string {
+    const styleguideLabel = barrelType === BarrelType.Project ? "/styleguide" : "";
+    return `${getBarrelWebUrl(barrelId, barrelType)}${styleguideLabel}/components`;
+}
+
+/**
+ * Returns a barrel's components' Mac app uri
+ * @param barrelId A barrel id.
+ * @param barrelType A barrel type.
+ */
+function getComponentsAppUri(barrelId: string, barrelType: BarrelType): string {
+    const barrelIdKey = barrelType === BarrelType.Project ? "pid" : "stid";
+    return `${configuration.appUri}components?${barrelIdKey}=${barrelId}`;
+}
+
 function getComponentUri(
     barrelId: string, barrelType: BarrelType, componentId: string, applicationType: ApplicationType
 ) {
@@ -73,8 +105,7 @@ function getComponentUri(
  * @param componentId A component id.
  */
 function getComponentAppUri(barrelId: string, barrelType: BarrelType, componentId: string): string {
-    const barrelIdKey = barrelType === BarrelType.Project ? "pid" : "stid";
-    return `${configuration.appUri}components?coids=${componentId}&${barrelIdKey}=${barrelId}`;
+    return `${getComponentsAppUri(barrelId, barrelType)}&coids=${componentId}`;
 }
 
 /**
@@ -84,8 +115,7 @@ function getComponentAppUri(barrelId: string, barrelType: BarrelType, componentI
  * @param componentId A component id.
  */
 function getComponentWebUrl(barrelId: string, barrelType: BarrelType, componentId: string): string {
-    const styleguideLabel = barrelType === BarrelType.Project ? "/styleguide" : "";
-    return `${getBarrelWebUrl(barrelId, barrelType)}${styleguideLabel}/components?coid=${componentId}`;
+    return `${getComponentsWebUrl(barrelId, barrelType)}?coid=${componentId}`;
 }
 
 function getComponentSectionUri(
@@ -170,6 +200,7 @@ export {
     getBarrelUri,
     getBarrelAppUri,
     getBarrelWebUrl,
+    getComponentsUri,
     getComponentUri,
     getComponentAppUri,
     getComponentWebUrl,

--- a/src/sidebar/zeplinComponent/tree/BarrelZeplinComponentsTreeItem.ts
+++ b/src/sidebar/zeplinComponent/tree/BarrelZeplinComponentsTreeItem.ts
@@ -6,7 +6,9 @@ import TreeItemContextProvider from "../../../common/vscode/tree/TreeItemContext
 import TreeItemContext from "../../../common/domain/tree/TreeItemContext";
 import ZeplinUriProvider from "../../openInZeplin/model/ZeplinUriProvider";
 import ApplicationType from "../../../common/domain/openInZeplin/model/ApplicationType";
-import { getBarrelUri } from "../../../common/domain/openInZeplin/util/zeplinUris";
+import { getComponentsUri } from "../../../common/domain/openInZeplin/util/zeplinUris";
+import BarrelType from "../../../common/domain/barrel/BarrelType";
+import localization from "../../../localization";
 
 const contextProvider = new TreeItemContextProvider(
     TreeItemContext.ZeplinComponentBarrel,
@@ -14,8 +16,13 @@ const contextProvider = new TreeItemContextProvider(
 );
 
 export default class BarrelZeplinComponentsTreeItem extends TreeItem implements ZeplinUriProvider {
-    public constructor(public barrel: BarrelDetails, title: string | undefined, parent: TreeItem | undefined) {
-        super(title ?? barrel.name, parent, contextProvider, vscode.TreeItemCollapsibleState.Collapsed);
+    public constructor(public barrel: BarrelDetails, parent: TreeItem | undefined) {
+        super(
+            barrel.type === BarrelType.Project ? localization.sidebar.zeplinComponent.localStyleguide : barrel.name,
+            parent,
+            contextProvider,
+            vscode.TreeItemCollapsibleState.Collapsed
+        );
         this.setRemoteIconPath(barrel.thumbnail);
     }
 
@@ -25,6 +32,6 @@ export default class BarrelZeplinComponentsTreeItem extends TreeItem implements 
     }
 
     public getZeplinUri(applicationType: ApplicationType): string {
-        return getBarrelUri(this.barrel.id, this.barrel.type, applicationType);
+        return getComponentsUri(this.barrel.id, this.barrel.type, applicationType);
     }
 }

--- a/src/sidebar/zeplinComponent/tree/ZeplinComponentsTreeItem.ts
+++ b/src/sidebar/zeplinComponent/tree/ZeplinComponentsTreeItem.ts
@@ -1,6 +1,5 @@
 import * as vscode from "vscode";
 import Barrel from "../../../common/domain/barrel/Barrel";
-import BarrelType from "../../../common/domain/barrel/BarrelType";
 import TreeItem from "../../../common/vscode/tree/TreeItem";
 import CumulativeBarrelDetailsStore from "../data/CumulativeBarrelDetailsStore";
 import ExpandedErrorTreeItem from "../../../common/vscode/tree/ExpandedErrorTreeItem";
@@ -31,13 +30,7 @@ export default class ZeplinComponentsTreeItem extends TreeItem {
             const error = errors?.[0];
             const errorItems = error ? [new ExpandedErrorTreeItem(error.id, error.message, this)] : [];
             return [
-                ...data.map((barrelDetails, index) => new BarrelZeplinComponentsTreeItem(
-                    barrelDetails,
-                    index === 0 && barrelDetails.type === BarrelType.Project
-                        ? localization.sidebar.zeplinComponent.localStyleguide
-                        : undefined,
-                    this
-                )),
+                ...data.map(barrelDetails => new BarrelZeplinComponentsTreeItem(barrelDetails, this)),
                 ...errorItems
             ];
         }


### PR DESCRIPTION
Components of barrels are opened when a styleguide or project's parent styleguide link is opened