### PR TITLE
Fix shortcuts blocking Terminal: Clear command

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,12 +184,14 @@
             {
                 "command": "zeplin.sidebar.jumpTo",
                 "key": "ctrl+k j",
-                "mac": "cmd+k j"
+                "mac": "cmd+k j",
+                "when": "!terminalFocus"
             },
             {
                 "command": "workbench.view.extension.zeplin",
                 "key": "ctrl+k z",
-                "mac": "cmd+k z"
+                "mac": "cmd+k z",
+                "when": "!terminalFocus"
             }
         ],
         "commands": [


### PR DESCRIPTION
Clearing terminal command has default shortcut of Cmd+k when terminal
has focus. So Zeplin commands are changed to be active only when terminal
is not focused.

Resolves https://github.com/zeplin/vscode-extension/issues/90