### PR TITLE
Fix logging on component file renames

### DIFF
--- a/src/coco/component/fileChange/componentRenameUtil.ts
+++ b/src/coco/component/fileChange/componentRenameUtil.ts
@@ -3,6 +3,7 @@ import * as configUtil from "../../config/util/configUtil";
 import { getRelativePathToRootFolder } from "../../../common/vscode/workspace/workspaceUtil";
 import { PATH_SEPARATOR } from "../../../common/general/pathUtil";
 import { wrapWithLogs } from "../../../log/util/logUtil";
+import Logger from "../../../log/Logger";
 
 type FileChanges = {
     oldUri: vscode.Uri;
@@ -59,14 +60,14 @@ function updateComponentPaths(fileChanges: FileChanges) {
     }
 
     if (shouldSaveOldConfig) {
-        console.log(
+        Logger.log(
             `Config #${configUtil.getConfigPaths().indexOf(oldConfigPath)} updated for component path change`
         );
         configUtil.saveConfig(oldConfigPath, oldConfig);
     }
 
     if (shouldSaveNewConfig) {
-        console.log(
+        Logger.log(
             `Config #${configUtil.getConfigPaths().indexOf(newConfigPath)} also updated for component path change`
         );
         configUtil.saveConfig(newConfigPath, newConfig);


### PR DESCRIPTION
Previously, these logs were written to console,
Now, it is saved for writing to log file when user wants to.
Also, It is written to console when consoleLogsEnabled is true
(but not in live extension)